### PR TITLE
fix: lable + reference syntax (TOKEN_LABEL)

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1879,7 +1879,7 @@ bool tree_sitter_typst_external_scanner_scan(
 
 	if (
 		valid_symbols[TOKEN_LABEL] && (
-			is_id_start(lex_next) || lex_next == '-' || lex_next == '_'
+			is_id_continue(lex_next) || lex_next == '-' || lex_next == '.' || lex_next == ':'
 	)) {
 		lex_advance();
 		while (is_id_continue(lex_next) || lex_next == '-' || lex_next == '.' || lex_next == ':') {


### PR DESCRIPTION
When writing my assignment today, I noticed that label and reference can starts with number, like `<123>`, `@123`.
[Typst Source Code](https://github.com/typst/typst/blob/2f795b5c07171affa0709195a9dae3ed5c0afbeb/crates/typst-syntax/src/lexer.rs#L169)
```rust
            '@' => self.ref_marker(),
            // ...
            _ => self.text(),
```
`ref_marker` appears before `text` and the definition of [ref_marker](https://github.com/typst/typst/blob/2f795b5c07171affa0709195a9dae3ed5c0afbeb/crates/typst-syntax/src/lexer.rs#L281) uses only `is_id_continue` function. 

---
I'm busy with academic stuffs recent months. Sorry for lazy contribution.  