### PR TITLE
Include 'scanner.c' in the python binding sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_typst/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c",
             ],
             extra_compile_args=(
                 ["-std=c11"] if system() != 'Windows' else []


### PR DESCRIPTION
This PR adds `/src/scanner.c` to the sources list in `setup.py` which I think was forgotten and that causes an `undefined symbol: tree_sitter_typst_external_scanner_create` error when using the python binding.