### PR TITLE
include scanner in go bindings

### DIFF
--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,7 +2,7 @@ package tree_sitter_typst
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
-// // NOTE: if your language has an external scanner, add it here.
+// #include "../../src/scanner.c"
 import "C"
 
 import "unsafe"


### PR DESCRIPTION
Including scanner.c fixes the issue #41.