### PR TITLE
Use '--file-name' instead of '-f' for test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 test: src/parser.c
-	tree-sitter test -f Test
+	tree-sitter test --file-name Test
 
 all: src/parser.c
 	tree-sitter test
 
 fixme: src/parser.c
-	tree-sitter test -f Fixme
+	tree-sitter test --file-name Fixme
 
 src/parser.c: grammar.js
 	tree-sitter generate


### PR DESCRIPTION
In tree-sitter 0.26.8 (commit 963b5a5a97) built on Debian GNU/Linux forky/sid ('testing' distro updated today), the 'tree-sitter test' subcommand does not support '-f'; it only supports the long option '--file-name'.